### PR TITLE
fix(prometheus-exporter): remove csv-only config keys from the example

### DIFF
--- a/src/plugins/3_outputs/prometheus-exporter.md
+++ b/src/plugins/3_outputs/prometheus-exporter.md
@@ -20,8 +20,6 @@ host = "0.0.0.0"
 prefix = ""
 suffix = "_alumet"
 port = 9091
-append_unit_to_metric_name = true
-use_unit_display_name = true
 add_attributes_to_labels = true
 ```
 


### PR DESCRIPTION
Context: [alumet-dev/alumet#433](https://github.com/alumet-dev/alumet/issues/433)

`append_unit_to_metric_name` and `use_unit_display_name` on the prometheus-exporter page don't exist in that plugin's `Config` (which is `deny_unknown_fields`) so the documented example fails to load as-is. They belong to the csv plugin (`[plugins.csv]` in the packaged conffile), the page likely inherited them by copy